### PR TITLE
fix: self-host fonts for static build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "nextn",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/inter": "5.2.6",
+        "@fontsource-variable/literata": "5.2.6",
+        "@fontsource/great-vibes": "5.2.6",
         "@genkit-ai/googleai": "^1.14.1",
         "@genkit-ai/next": "^1.14.1",
         "@hookform/resolvers": "^4.1.3",
@@ -1201,6 +1204,33 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.6.tgz",
+      "integrity": "sha512-jks/bficUPQ9nn7GvXvHtlQIPudW7Wx8CrlZoY8bhxgeobNxlQan8DclUJuYF2loYRrGpfrhCIZZspXYysiVGg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/literata": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/literata/-/literata-5.2.6.tgz",
+      "integrity": "sha512-9ggXmkaGKzJUvfiEX66m7iuDzkbKBN1t5ei4sHPSn5voeMeMUOi3NMuZ702mG0dXvuJVKOs4oe26AjfyHheshg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/great-vibes": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/great-vibes/-/great-vibes-5.2.6.tgz",
+      "integrity": "sha512-DdyS+X+4hLt+YYj3r+2baxSeV4Fah/hn1+588GqSp6Y1QdVFjpYLrChhBuMneP868Z/VHfwYQ4J2ney3zog97w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@genkit-ai/ai": {
       "version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "@fontsource-variable/inter": "5.2.6",
+    "@fontsource-variable/literata": "5.2.6",
+    "@fontsource/great-vibes": "5.2.6"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+@import '@fontsource-variable/inter/index.css';
+@import '@fontsource-variable/literata/index.css';
+@import '@fontsource/great-vibes/400.css';
+
 @layer base {
   :root {
     --background: 30 3% 25%; /* --charcoal */
@@ -25,6 +29,9 @@
     --ring: 12 55% 72%;
     --radius: 18px;
     --gap: clamp(14px, 2.2vw, 24px);
+    --font-inter: 'Inter Variable', sans-serif;
+    --font-literata: 'Literata Variable', serif;
+    --font-great-vibes: 'Great Vibes', cursive;
   }
 
   .dark {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,25 +4,6 @@ import { cn } from '@/lib/utils';
 import { Toaster } from '@/components/ui/toaster';
 import Header from '@/components/header';
 import Footer from '@/components/footer';
-import { Inter, Literata, Great_Vibes } from 'next/font/google';
-
-const inter = Inter({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-inter',
-});
-
-const literata = Literata({
-  subsets: ['latin'],
-  weight: ['500', '600', '700'],
-  variable: '--font-literata',
-});
-
-const greatVibes = Great_Vibes({
-  subsets: ['latin'],
-  weight: ['400'],
-  variable: '--font-great-vibes',
-});
 
 
 export const metadata: Metadata = {
@@ -36,7 +17,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={cn('dark scroll-smooth', inter.variable, literata.variable, greatVibes.variable)}>
+    <html lang="en" className="dark scroll-smooth">
       <body className={cn('min-h-screen bg-background font-body antialiased')}>
         <div className="relative flex min-h-dvh flex-col bg-background">
           <Header />


### PR DESCRIPTION
## Summary
- self-host Inter, Literata, and Great Vibes fonts via `@fontsource` packages
- strip `next/font` usage to prevent network font fetch failures
- wire CSS variables so GitHub Pages static export builds cleanly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Requires manual ESLint configuration)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b27f11d948832f97f9895a6b002a80