### PR TITLE
feat: handle otf download for Brother Home font

### DIFF
--- a/scripts/scrape-artkrati.ts
+++ b/scripts/scrape-artkrati.ts
@@ -42,7 +42,7 @@ const saveImage = async (url: string, subdir: string) => {
   return `/assets/artkrati/${subdir}/${name}`;
 };
 
-const extractText = ($el: cheerio.Cheerio) =>
+const extractText = ($el: any) =>
   $el.text().replace(/\s+\n/g, '\n').replace(/\s{2,}/g, ' ').trim();
 
 const writeMDX = (path: string, data: any, body: string) => {
@@ -79,7 +79,7 @@ const load = async (url: string) => {
   // PORTFOLIO
   const $gal = await load(`${SITE}/projects-6`);
   const items: { src: string; alt: string; caption: string }[] = [];
-  $gal('img').each((_i, el) => {
+  $gal('img').each((_i: number, el: any) => {
     const src = $gal(el).attr('src') || '';
     const alt = $gal(el).attr('alt') || '';
     const caption =

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,7 +1,7 @@
 import localFont from 'next/font/local';
 
 export const brotherHome = localFont({
-  src: '../../public/fonts/BrotherHome.ttf',
+  src: '../../public/fonts/BrotherHome.otf',
   display: 'swap',
   variable: '--font-brotherhome'
 });

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -1,0 +1,4 @@
+declare module 'adm-zip';
+declare module 'gray-matter';
+declare module '@sindresorhus/slugify';
+declare module 'cheerio';


### PR DESCRIPTION
## Summary
- allow Brother Home font script to extract either TTF or OTF and save with correct extension
- switch local font reference to BrotherHome.otf
- add minimal type stubs and annotations for scripts to satisfy TypeScript

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck`
- `FONT_ACCEPT_LICENSE=1 npm run font:brotherhome` *(fails: connect ENETUNREACH dl.dafont.com:443)*

------
https://chatgpt.com/codex/tasks/task_e_68b28e30733c832f815b4dc3c608c9dc