### PR TITLE
chore: streamline header title

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -22,9 +22,7 @@ export default function Header() {
       <div className="container flex h-20 max-w-screen-2xl items-center px-4 md:px-6">
         <div className="flex flex-col">
           <Link href="/" className="flex items-center gap-2" prefetch={false}>
-            <span className="font-brand text-2xl sm:text-3xl md:text-4xl text-foreground">Aakrati</span>
-
-            <span className="font-brand text-3xl sm:text-4xl md:text-5xl text-foreground">Aakrati</span>
+            <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground">Aakrati</span>
           </Link>
           <div className="font-sans text-xs tracking-[.28em] uppercase text-muted-foreground ml-1">Interior Design Artist</div>
         </div>
@@ -57,8 +55,7 @@ export default function Header() {
               <div className="mb-8">
                 <div className="flex flex-col">
                   <Link href="/" className="flex items-center gap-2" prefetch={false}>
-                    <span className="font-brand text-2xl sm:text-3xl md:text-4xl text-foreground">Aakrati</span>
-                    <span className="font-brand text-3xl sm:text-4xl md:text-5xl text-foreground">Aakrati</span>
+                    <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground">Aakrati</span>
                   </Link>
                   <div className="font-sans text-xs tracking-[.28em] uppercase text-muted-foreground ml-1">Interior Design Artist</div>
                 </div>


### PR DESCRIPTION
## Summary
- remove duplicate header title
- reduce title sizing by one step for cleaner display

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b2ca4606c4832fa67dda0dbf420112