### PR TITLE
Reduce brand text size in header

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -22,7 +22,7 @@ export default function Header() {
       <div className="container flex h-20 max-w-screen-2xl items-center px-4 md:px-6">
         <div className="flex flex-col">
           <Link href="/" className="flex items-center gap-2" prefetch={false}>
-            <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground">Aakrati</span>
+            <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground scale-50 origin-left">Aakrati</span>
           </Link>
           <div className="font-sans text-xs tracking-[.28em] uppercase text-muted-foreground ml-1">Interior Design Artist</div>
         </div>
@@ -55,7 +55,7 @@ export default function Header() {
               <div className="mb-8">
                 <div className="flex flex-col">
                   <Link href="/" className="flex items-center gap-2" prefetch={false}>
-                    <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground">Aakrati</span>
+                    <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground scale-50 origin-left">Aakrati</span>
                   </Link>
                   <div className="font-sans text-xs tracking-[.28em] uppercase text-muted-foreground ml-1">Interior Design Artist</div>
                 </div>


### PR DESCRIPTION
## Summary
- scale down the brand text in the header to half size for better fit

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2ccb02878832f83c6375093e59594