### PR TITLE
chore: tighten header spacing

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -19,12 +19,12 @@ export default function Header() {
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/80 backdrop-blur-lg">
-      <div className="container flex h-20 max-w-screen-2xl items-center px-4 md:px-6">
-        <div className="flex flex-col">
+      <div className="container flex h-16 max-w-screen-2xl items-center px-4 md:px-6">
+        <div className="flex flex-col leading-none">
           <Link href="/" className="flex items-center gap-2" prefetch={false}>
-            <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground scale-50 origin-left">Aakrati</span>
+            <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground scale-75 origin-left">Aakrati</span>
           </Link>
-          <div className="font-sans text-xs tracking-[.28em] uppercase text-muted-foreground ml-1 scale-50 origin-left">Interior Design Artist</div>
+          <div className="font-sans text-xs tracking-[.28em] uppercase text-muted-foreground ml-1 mt-1 scale-75 origin-left">Interior Design Artist</div>
         </div>
         <nav className="hidden flex-col gap-6 text-lg font-medium md:flex md:flex-row md:items-center md:gap-5 md:text-sm lg:gap-6 ml-auto">
           {navLinks.map((link) => (
@@ -53,11 +53,11 @@ export default function Header() {
           <SheetContent side="right">
             <div className="flex flex-col h-full">
               <div className="mb-8">
-                <div className="flex flex-col">
+                <div className="flex flex-col leading-none">
                   <Link href="/" className="flex items-center gap-2" prefetch={false}>
-                    <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground scale-60 origin-left">Aakrati</span>
+                    <span className="font-brand text-xl sm:text-2xl md:text-3xl text-foreground scale-75 origin-left">Aakrati</span>
                   </Link>
-                  <div className="font-sans text-xs tracking-[.28em] uppercase text-muted-foreground ml-1 scale-60 origin-left">Interior Design Artist</div>
+                  <div className="font-sans text-xs tracking-[.28em] uppercase text-muted-foreground ml-1 mt-1 scale-75 origin-left">Interior Design Artist</div>
                 </div>
               </div>
               <nav className="grid gap-6 text-lg font-medium">


### PR DESCRIPTION
## Summary
- reduce header height and increase branding scale for better fit
- match branding scale in mobile navigation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for ESLint config)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2d92a2cbc832fb66e74425a2466b4